### PR TITLE
feat: TermsAndConditions and SignOutModal using RRC ui

### DIFF
--- a/src/components/Auth/SignOut/SignOutModal.js
+++ b/src/components/Auth/SignOut/SignOutModal.js
@@ -1,16 +1,6 @@
 import React, { Component, Fragment } from "react";
 import { Redirect } from "react-router-dom";
-import { Modal, Button } from 'antd';
-import { LogoutOutlined } from '@ant-design/icons';
-import styled from "styled-components";
-
-const MenuButton = styled(Button)`
-  margin-left: 10px;
-  color: #afb6bb; 
-  :hover {
-    color: red !important;
-  }
-`;
+import { VerticalItem, Modal, Button } from 'react-rainbow-components';
 
 class SignOutModal extends Component {
   constructor() {
@@ -27,7 +17,7 @@ class SignOutModal extends Component {
     });
   };
 
-  handleOk = e => {
+  handleConfirm = e => {
     console.log("Signing out");
     this.setState({
       visible: false,
@@ -44,21 +34,33 @@ class SignOutModal extends Component {
 
   render() {
     const { redirect } = this.state;
+    const {name, icon} = this.props;
     return(
       redirect ? 
         <Redirect to="/signed_out" />
       : 
-        <Fragment>
-          <MenuButton type="link" icon={<LogoutOutlined />} onClick={this.showModal}>
-            Sign out
-          </MenuButton>
-          <Modal
-              visible={this.state.visible}
-              onOk={this.handleOk}
-              onCancel={this.handleCancel}
-          >
-            Are you sure you want to sign out?
-          </Modal>
+      <Fragment>
+        <VerticalItem
+            name={name} 
+            label={name}
+            icon={icon}
+            onClick={this.showModal}
+        />
+        <Modal   
+          isOpen={this.state.visible}
+          onRequestClose={this.handleCancel}
+          title="Are you sure you want to exit?"
+        >
+          <section className="rainbow-flex rainbow-justify_end">
+              <Button
+                  className="rainbow-m-right_large"
+                  label="No"
+                  variant="destructive"
+                  onClick={this.handleCancel}
+              />
+              <Button label="Yes" variant="success" onClick={this.handleConfirm} />
+          </section>
+            </Modal>
         </Fragment>
       )
   };

--- a/src/components/Auth/SignUp/TermsAndConditions.js
+++ b/src/components/Auth/SignUp/TermsAndConditions.js
@@ -1,15 +1,8 @@
 import React, { Component, Fragment } from "react";
-import { Modal, Button, Checkbox } from 'antd';
-import styled from "styled-components";
+import { Modal, Button } from 'react-rainbow-components';
+import { Input } from 'react-rainbow-components';
 
 const termsAndConditions = `Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.`;
-
-const Link = styled(Button)`
-  border: none !important;
-  padding: 5px;
-  color: #39b5fb; 
-`;
-Link.displayName = "Link";
 
 class TermsAndConditions extends Component {
   state = {
@@ -24,18 +17,6 @@ class TermsAndConditions extends Component {
     });
   };
 
-  handleOk = () => {
-    this.setState({
-      confirmLoading: true,
-    });
-    setTimeout(() => {
-      this.setState({
-        visible: false,
-        confirmLoading: false,
-      });
-    }, 500);
-  };
-
   handleCancel = () => {
     console.log('Clicked cancel button');
     this.setState({
@@ -44,20 +25,22 @@ class TermsAndConditions extends Component {
   };
 
   render() {
-    const { visible, confirmLoading, ModalText } = this.state;
+    const { visible, ModalText } = this.state;
     return (
       <Fragment>
-        <Checkbox>
-          I have read the <Link onClick={this.showModal}> terms and conditions</Link>
-        </Checkbox>
+        <Input
+          className="rainbow-m-around_medium"
+          type="checkbox"
+          error="This Field is Required"
+          label="I have read the"
+        />
+        <Button variant="base" label="terms and conditions" onClick={this.showModal} />
         <Modal
+          isOpen={visible}
+          onRequestClose={this.handleCancel}
           title="Terms and Conditions"
-          visible={visible}
-          onOk={this.handleOk}
-          confirmLoading={confirmLoading}
-          onCancel={this.handleCancel}
         >
-          <p>{ModalText}</p>
+           <p>{ModalText}</p>
         </Modal>
       </Fragment>
     );

--- a/src/components/Layout/SideNav/SideNav.js
+++ b/src/components/Layout/SideNav/SideNav.js
@@ -2,6 +2,7 @@ import React, {useState} from 'react';
 import styled from 'styled-components';
 import {SIDE_NAV_CONFIG} from "./SideNavConfig";
 import { VerticalNavigation, VerticalSection, VerticalItem } from 'react-rainbow-components';
+import SignOutModal from "../../Auth/SignOut/SignOutModal";
 
 const SideNavContainer = styled.section`
     padding-top: 10px;
@@ -25,14 +26,17 @@ const SideNav = () => {
             >
                 <VerticalSection>
                     {Object.keys(SIDE_NAV_CONFIG).map((currentMenuItem) => {
-                        const {icon, name, path} = SIDE_NAV_CONFIG[currentMenuItem];
+                        const {icon, name, path, modal} = SIDE_NAV_CONFIG[currentMenuItem];
                         return(
-                            <VerticalItem
-                                name={name} 
-                                label={name}
-                                icon={icon}
-                                href={path}
-                            />
+                            modal ?
+                                <SignOutModal name={name} icon={icon} path={path} />
+                            : 
+                                <VerticalItem
+                                    name={name} 
+                                    label={name}
+                                    icon={icon}
+                                    href={path}
+                                />
                         )
                     })}
                 </VerticalSection>

--- a/src/components/Layout/SideNav/SideNavConfig.js
+++ b/src/components/Layout/SideNav/SideNavConfig.js
@@ -34,7 +34,8 @@ const SIDE_NAV_CONFIG = {
     SIGN_OUT: {
         icon: <FontAwesomeIcon icon={faSignOutAlt} />,
         name: SCREEN_NAMES.SIGN_OUT, 
-        path: "/signed_out"
+        path: "/signed_out", 
+        modal: true
     }
 };
 


### PR DESCRIPTION
**Changes**
- migrated `TermsAndConditions` to use react-rainbow-components
- migrated `SignOutModal` to use react-rainbow-components
- trigger modal to open when "Sign out" side nav button is selected
- updated SideNavConfig to contain prop modal and value true

**UI**
> <img src="https://im3.ezgif.com/tmp/ezgif-3-deacebf767d3.gif" alt="A gif showing the SignOutModal" width=500 />
