### PR TITLE
fix: EditTranslations form styling

### DIFF
--- a/src/components/Questions/Actions/EditDrawer.js
+++ b/src/components/Questions/Actions/EditDrawer.js
@@ -24,14 +24,14 @@ const EditDrawer = ({
     editDrawerType, 
     dispatch 
 }) => {
-    const { header, subheader, slideFrom } = DRAWER_CONFIG.EDIT_LANGUAGE_DRAWER_CONFIG;
+    const { header, subheader, slideFrom, size } = DRAWER_CONFIG.EDIT_LANGUAGE_DRAWER_CONFIG;
 
     const getDrawerContent = () => {
-        const { editLanguage, editNextQuestion } = DRAWER_CONFIG.DRAWER_TYPES;
+        const { editTranslation, editNextQuestion } = DRAWER_CONFIG.DRAWER_TYPES;
 
         switch (editDrawerType) {
-            case (editLanguage.type):
-                return editLanguage.content;
+            case (editTranslation.type):
+                return editTranslation.content;
             case (editNextQuestion.type): 
                 return editNextQuestion.content;
             default: 
@@ -80,6 +80,7 @@ const EditDrawer = ({
     return (
         <div className="rainbow-p-around_small rainbow-flex rainbow-flex_wrap  rainbow-align-content_center">
             <Drawer
+                size={size}
                 header={header}
                 slideFrom={slideFrom}
                 isOpen={editDrawerVisible}

--- a/src/components/Questions/Actions/EditTranslations.js
+++ b/src/components/Questions/Actions/EditTranslations.js
@@ -1,6 +1,15 @@
 import React from "react";
+import styled from "styled-components";
 import DRAWER_CONFIG from "../../../configs/drawers";
 import { Input } from "react-rainbow-components";
+
+const FormContainer = styled.form`
+    margin-top: 2.0vh;
+    div > label {
+        align-self: flex-start;
+        padding-left: 1.0vh;
+    }
+`;
 
 const EditTranslations = () => {
     const { labels } = DRAWER_CONFIG.EDIT_LANGUAGE_DRAWER_CONFIG;
@@ -9,7 +18,7 @@ const EditTranslations = () => {
             .inputProps;
 
     return(
-        <form key="edit-translations-form">
+        <FormContainer key="edit-translations-form">
             {Object.keys(labels).map((currentLanguage) => {
                 const {label, key } = labels[currentLanguage];
                 return ( 
@@ -22,7 +31,7 @@ const EditTranslations = () => {
                     />
                 )
             })}
-        </form>
+        </FormContainer>
     );
 };
 

--- a/src/components/Questions/Actions/QuestionActions.js
+++ b/src/components/Questions/Actions/QuestionActions.js
@@ -41,10 +41,10 @@ const QuestionActions = ({
     };
 
     const onEdit = () => {
-        const { editLanguage } = DRAWER_CONFIG.DRAWER_TYPES;
+        const { editTranslation } = DRAWER_CONFIG.DRAWER_TYPES;
         dispatch({
             type: 'EDIT_QUESTION_ACTION',
-            editDrawerType: editLanguage.type, 
+            editDrawerType: editTranslation.type, 
             editDrawerVisible: true 
         });
     };

--- a/src/configs/drawers.js
+++ b/src/configs/drawers.js
@@ -3,8 +3,7 @@ import EditTranslations from "../components/Questions/Actions/EditTranslations";
 import EditNextQuestionField from "../components/Questions/Actions/EditNextQuestionField";
 
 const INPUT_CONFIG = {
-    type: "text", 
-    style: { width: 300 }, 
+    type: "text",  
     className: "rainbow-p-around_medium"
 };
 
@@ -32,7 +31,8 @@ const EDIT_LANGUAGE_DRAWER_CONFIG = {
     },
     header: "Edit action",
     subheader: "Edit and translate the following actions.", 
-    slideFrom: "right"
+    slideFrom: "right", 
+    size: "small"
 };
 
 const TEXTAREA_CONFIG = {
@@ -47,12 +47,13 @@ const EDIT_NEXT_QUESTION_DRAWER_CONFIG = {
     }, 
     header: "Edit the next question", 
     subheader: "Edit the JSON logic used to retrieve the next question", 
-    slideFrom: "right"
+    slideFrom: "right", 
+    size: "small"
 };
 
 const DRAWER_TYPES = {
-    editLanguage: {
-        type: "editLanguage", 
+    editTranslation: {
+        type: "editTranslation", 
         content: <EditTranslations />
     },  
     editNextQuestion: {


### PR DESCRIPTION
**Changes**
- update `editLanguages` to `editTranslations`
- add size to each drawer config
- left-align translation input labels
- add margin + padding

**UI**
> ![image](https://user-images.githubusercontent.com/23146829/84981204-3752c680-b0f1-11ea-80f3-810184940dd9.png)

