### PR TITLE
feat: display + edit all languages

### DIFF
--- a/src/components/Questions/Actions/EditTranslations.js
+++ b/src/components/Questions/Actions/EditTranslations.js
@@ -18,21 +18,19 @@ const EditTranslations = ({ questionActionSelected }) => {
             .EDIT_LANGUAGE_DRAWER_CONFIG
             .inputProps;
 
-    // TODO: Make questionActionSelected into object
-    // that contains all translated strings. Refrained 
-    // from this since no translations have been made.
+    const { eng, amh, orm, tig } = questionActionSelected;
     const [translations, setTranslations] = useState({
-        eng: questionActionSelected, 
-        arm: "", 
-        orm: "", 
-        tig: ""
+        eng,
+        amh,
+        orm, 
+        tig
     });
 
-    const onEdit = (e, key) => {
+    const onEdit = (key, e) => {
         const edit = e ? e.target.value : "";
         setTranslations({
             ...translations, 
-            key: edit
+            [key]: edit
         });
     };
 
@@ -46,7 +44,7 @@ const EditTranslations = ({ questionActionSelected }) => {
                         type={type}
                         label={label}
                         style={style}
-                        onChange={() => onEdit(key)}
+                        onChange={e => onEdit(key, e)}
                         className={className}
                         value={translations[key]}
                     />

--- a/src/components/Questions/Actions/QuestionActions.js
+++ b/src/components/Questions/Actions/QuestionActions.js
@@ -31,11 +31,17 @@ const QuestionActions = ({
     const filterActions = () => {
         if (questionSelected.multiple_choice) {
             return Object.values(questionSelected.multiple_choice).map((currentMC) => {
-                return currentMC.text.eng;
+                return {
+                    english: currentMC.text.eng,
+                    allLangs: currentMC.text
+                };
             })
         } else {
             return Object.values(questionSelected.actions).map((currentActionKey) => {
-                return currentActionKey.text.eng;
+                return {
+                    english: currentActionKey.text.eng,
+                    allLangs: currentActionKey.text
+                };
             })
         };
     };
@@ -44,7 +50,7 @@ const QuestionActions = ({
         const { editTranslation } = DRAWER_CONFIG.DRAWER_TYPES;
         dispatch({
             type: 'EDIT_QUESTION_ACTION',
-            questionActionSelected: currentAction, 
+            questionActionSelected: currentAction.allLangs, 
             editDrawerType: editTranslation.type, 
             editDrawerVisible: true 
         });
@@ -56,12 +62,12 @@ const QuestionActions = ({
             return allActions.map((currentAction) => {
                 return(
                     <PaddedContainer 
-                        key={`${questionSelected.id}-${currentAction}`}
+                        key={`${questionSelected.id}-${currentAction.english}`}
                     >
-                         {currentAction}
+                         {currentAction.english}
                         <ButtonIcon 
-                            key={currentAction}
-                            title={currentAction}
+                            key={currentAction.english}
+                            title={currentAction.english}
                             variant="border" 
                             size="small" 
                             style={buttonIconStyle}


### PR DESCRIPTION
**Changes**
- update the redux state to contain all languages of the `questionActionSelected` instead of only english
- render all languages in the drawer
- all all language input fields to be editable and maintained by `EditTranslations` state

**Note**
- No translations have been made in the app yet, hence them all being English.
- These translations are being pulled from the database. Once the translations have been added to the databases, the changes will be automatically reflected in the drawer.

**UI**
> ![image](https://user-images.githubusercontent.com/23146829/84986519-ed231280-b0fb-11ea-8ec6-b2bb30a31db7.png)

